### PR TITLE
docker compose for mac set up

### DIFF
--- a/docker-compose-OSx.yml
+++ b/docker-compose-OSx.yml
@@ -1,0 +1,149 @@
+version: "3.7"
+services:
+
+  zookeeper:
+    image: wurstmeister/zookeeper:latest
+    container_name: zookeeper
+    expose:
+      - "2181"
+    ports:
+      - 2181:2181
+    volumes:
+      - kafka_zookeeper:/opt/zookeeper-3.4.13/data
+
+  kafka1:
+    image: wurstmeister/kafka:2.12-2.2.0
+    container_name: kafka1
+    command: [start-kafka.sh]
+    expose:
+      - "9092"
+    ports:
+      - 9092:9092
+    environment:
+      #      KAFKA_ADVERTISED_HOST_NAME: 172.25.0.12
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ADVERTISED_HOST_NAME: kafka1
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://localhost:19092
+      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://0.0.0.0:19092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_OPTS: -javaagent:/prometheus/jmx_prometheus_javaagent-0.3.1.jar=8080:/prometheus/kafka-0-8-2.yml
+    volumes:
+      - ./kafka/prometheus:/prometheus
+      - kafka_kafka1:/opt/kafka_2.12-2.2.0/logs
+    depends_on:
+      - "zookeeper"
+
+  kafka2:
+    image: wurstmeister/kafka:2.12-2.2.0
+    container_name: kafka2
+    command: [start-kafka.sh]
+    expose:
+      - "9093"
+    ports:
+      - 9093:9092
+      - 8081:8080
+    environment:
+      #      KAFKA_ADVERTISED_HOST_NAME: 172.25.0.13
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_HOST_NAME: kafk2
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://:9093,OUTSIDE://localhost:19093
+      KAFKA_LISTENERS: INSIDE://:9093,OUTSIDE://0.0.0.0:19093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_OPTS: -javaagent:/prometheus/jmx_prometheus_javaagent-0.3.1.jar=8080:/prometheus/kafka-0-8-2.yml
+    volumes:
+      - ./kafka/prometheus:/prometheus
+      - kafka_kafka2:/opt/kafka_2.12-2.2.0/logs
+    depends_on:
+      - "zookeeper"
+
+
+  kafka_manager:
+    image: hlebalbau/kafka-manager:1.3.3.18
+    container_name: kafka_manager
+    expose:
+      - "9000"
+    ports:
+      - 9000:9000
+    environment:
+      ZK_HOSTS: "zookeeper:2181"
+      APPLICATION_SECRET: "random-secret"
+    command: -Dpidfile.path=/dev/null
+    depends_on:
+      - "zookeeper"
+      - "kafka1"
+      - "kafka2"
+
+  prometheus:
+    image: prom/prometheus:v2.8.1
+    container_name: prometheus
+    expose:
+      - "9090"
+    ports:
+      - 9090:9090
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus/flink.rules.yml:/etc/prometheus/flink.rules.yml
+    depends_on:
+      - "zookeeper"
+      - "kafka1"
+      - "kafka2"
+    links:
+      - kafka1
+      - kafka2
+      - alertmanager
+
+  alertmanager:
+    image: prom/alertmanager
+    container_name: alertmanager
+    privileged: true
+    volumes:
+      - ./alertmanager/alertmanager.yml:/alertmanager.yml
+    command:
+      - '--config.file=/alertmanager.yml'
+    ports:
+      - '9096:9093'
+
+  grafana:
+    image: grafana/grafana:6.1.1
+    container_name: grafana
+    expose:
+      - "3000"
+    ports:
+      - 3000:3000
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=password
+    volumes:
+      - ./grafana/provisioning/:/etc/grafana/provisioning/
+    depends_on:
+      - "prometheus"
+    links:
+      - prometheus:prometheus
+
+  zeppelin:
+    image: apache/zeppelin:0.8.1
+    hostname: zeppelin
+    container_name: zeppelin
+    expose:
+      - "8080"
+      - "8443"
+      - "4040"
+    ports:
+      - 8080:8080
+      - 8443:8443
+      - 4040:4040
+    environment:
+      KAFKA_BROKER_URL_1: 'kafka-1:9092'
+      KAFKA_BROKER_URL_2: 'kafka-2:9093'
+    volumes:
+      - ./zeppelin/datadrive:/datadrive
+      - ./zeppelin/pyspark-notebooks:/zeppelin/notebook
+      - ./zeppelin/zeppelin-interpreters/interpreter.json:/zeppelin/conf/interpreter.json
+
+volumes:
+  kafka_zookeeper:
+  kafka_kafka1:
+  kafka_kafka2:
+


### PR DESCRIPTION
As OSX  does not currently support the bridge network in docker, I have created a new docker-compose file that utilizes the host network instead of the bridge for mac.